### PR TITLE
Add config generation and systemd service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ make gui-all
 
 # Debug-Modus
 ./mididaemon -debug
+
+# Beispiel-Konfiguration erzeugen
+./mididaemon -generate-config
 ```
 
 ### Web-GUI
@@ -97,6 +100,15 @@ make run-gui
 ```
 
 Die GUI ist dann unter `http://localhost:8080` erreichbar.
+
+### Als systemd-Dienst
+
+Eine Beispiel-Service-Datei befindet sich in `docs/mididaemon.service`. Nach dem
+Kopieren nach `/etc/systemd/system/` kann der Dienst so aktiviert werden:
+
+```bash
+sudo systemctl enable --now mididaemon.service
+```
 
 #### GUI-Features
 

--- a/cmd/mididaemon/main.go
+++ b/cmd/mididaemon/main.go
@@ -28,12 +28,22 @@ func main() {
 	verbose := flag.Bool("verbose", false, "Ausführliche Log-Ausgabe")
 	debug := flag.Bool("debug", false, "Aktiviere Debug-Modus")
 	logLevel := flag.String("log-level", "", "Log-Level (debug, info, warn, error)")
+	generateCfg := flag.Bool("generate-config", false, "Erzeugt eine Standard-Konfigurationsdatei")
 	showVersion := flag.Bool("version", false, "Versionsinformationen anzeigen")
 
 	flag.Parse()
 
 	if *showVersion {
 		printVersion()
+		return
+	}
+
+	if *generateCfg {
+		if err := config.GenerateDefaultFile(*configPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Fehler beim Erzeugen der Konfiguration: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Konfigurationsdatei %s erstellt\n", *configPath)
 		return
 	}
 

--- a/docs/mididaemon.service
+++ b/docs/mididaemon.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=MidiDaemon background service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/mididaemon -config /etc/mididaemon/config.json
+Restart=on-failure
+User=mididaemon
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,3 +284,61 @@ func Save(configPath string, config *Config) error {
 
 	return nil
 }
+
+// Default gibt eine Standard-Konfiguration zurück
+func Default() *Config {
+	return &Config{
+		MIDI: MIDIConfig{
+			Channel: -1,
+			Timeout: 30,
+		},
+		General: GeneralConfig{
+			LogLevel:    "info",
+			AutoRestart: true,
+			ActionDelay: 100,
+		},
+		Mappings: []Mapping{
+			{
+				Name:    "Volume Up",
+				Enabled: true,
+				Event: MIDIEvent{
+					Type:       "control_change",
+					Controller: 7,
+					Value:      64,
+				},
+				Action: Action{
+					Type: "volume",
+					Parameters: map[string]interface{}{
+						"direction": "up",
+						"percent":   5,
+					},
+				},
+			},
+			{
+				Name:    "Volume Down",
+				Enabled: true,
+				Event: MIDIEvent{
+					Type:       "control_change",
+					Controller: 7,
+					Value:      0,
+				},
+				Action: Action{
+					Type: "volume",
+					Parameters: map[string]interface{}{
+						"direction": "down",
+						"percent":   5,
+					},
+				},
+			},
+		},
+	}
+}
+
+// GenerateDefaultFile speichert eine Standard-Konfiguration, wenn keine Datei existiert
+func GenerateDefaultFile(configPath string) error {
+	if _, err := os.Stat(configPath); err == nil {
+		return fmt.Errorf("Konfigurationsdatei %s existiert bereits", configPath)
+	}
+	cfg := Default()
+	return Save(configPath, cfg)
+}


### PR DESCRIPTION
## Summary
- allow generating a default configuration via `-generate-config`
- provide default configuration helper functions
- document service setup and config generation
- add example `systemd` service file

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686289bb4e9483269a3986cc7832c620